### PR TITLE
fix(menu-sidebar): remove conditional visibility for logout link

### DIFF
--- a/byteassist-frontend/src/app/features/components/menu-sidebar/menu-sidebar.component.html
+++ b/byteassist-frontend/src/app/features/components/menu-sidebar/menu-sidebar.component.html
@@ -118,7 +118,7 @@
       <li class="nav-item nav-item-seperator">
         <div class="nav-border"></div>
       </li>
-      <li class="nav-item" *ngIf="clientLinksVisible">
+      <li class="nav-item">
         <a
           class="nav-link flex items-center menu-padding"
           (click)="logout()"


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Ensure logout link is always visible by removing the *ngIf conditional rendering