### PR TITLE
feature/implement-equipment-crud

### DIFF
--- a/byteassist-backend/src/main/java/com/ufpr/byteassist_backend/controller/EquipmentController.java
+++ b/byteassist-backend/src/main/java/com/ufpr/byteassist_backend/controller/EquipmentController.java
@@ -1,0 +1,63 @@
+package com.ufpr.byteassist_backend.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ufpr.byteassist_backend.model.Equipment;
+import com.ufpr.byteassist_backend.service.EquipmentService;
+import com.ufpr.byteassist_backend.validation.ValidationGroups;
+
+@RestController
+@RequestMapping("/api/equipment")
+public class EquipmentController {
+    private final EquipmentService equipmentService;
+
+    public EquipmentController(EquipmentService equipmentService) {
+        this.equipmentService = equipmentService;
+    }
+
+    @GetMapping()
+    public ResponseEntity<List<Equipment>> getAllEquipments() {
+        return equipmentService.getAllEquipments();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Equipment> getEquipmentById(@PathVariable String id) {
+        return equipmentService.getEquipmentById(id);
+    }
+    
+    @GetMapping("/byType")
+    public ResponseEntity<List<Equipment>> getEquipmentsByType(@RequestParam String type) {
+        return equipmentService.getEquipmentsByType(type);
+    }
+
+    @PostMapping()
+    @PreAuthorize("hasRole('EMPLOYEE')")
+    public ResponseEntity<Equipment> createEquipment(@Validated(ValidationGroups.Create.class) @RequestBody Equipment equipment) {
+        return equipmentService.createEquipment(equipment);
+    }
+
+    @PatchMapping("/{id}")
+    @PreAuthorize("hasRole('EMPLOYEE')")
+    public ResponseEntity<Equipment> updateEquipment(@PathVariable String id, @Validated @RequestBody Equipment equipment) {
+        return equipmentService.updateEquipment(id, equipment);
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('MANAGER')")
+    public ResponseEntity<Void> deleteEquipment(@PathVariable String id) {
+        return equipmentService.deleteEquipment(id);
+    }
+}

--- a/byteassist-backend/src/main/java/com/ufpr/byteassist_backend/controller/TaskController.java
+++ b/byteassist-backend/src/main/java/com/ufpr/byteassist_backend/controller/TaskController.java
@@ -63,6 +63,31 @@ public class TaskController {
 
         return taskService.getTasksByUsername(username, type);
     }
+    
+    @GetMapping("/me")
+    public ResponseEntity<List<Task>> getCurrentUserTasks(
+            @RequestParam(name = "type", defaultValue = "creator") String type, 
+            @RequestParam(name = "status", required = false) String status) {
+
+        // Validate that type is either "creator" or "assignee"
+        if (!type.equals("creator") && !type.equals("assignee")) {
+            throw new IllegalArgumentException("Type parameter must be either 'creator' or 'assignee'");
+        }
+
+        // valid status: 'Aguardando Orçamento' | 'Aguardando Aprovação' | 'Aguardando Peças' | 'Em Andamento' | 'Concluído' | 'Rejeitado'
+        if (status != null && !java.util.regex.Pattern.compile("Aguardando Orçamento|Aguardando Aprovação|Aguardando Peças|Em Andamento|Concluído|Rejeitado", java.util.regex.Pattern.CANON_EQ).matcher(status).matches()) {
+            throw new IllegalArgumentException("Status parameter must be one of: 'Aguardando Orçamento', 'Aguardando Aprovação', 'Aguardando Peças', 'Em Andamento', 'Concluído', 'Rejeitado'");
+        }
+
+        // Get the current user from the security context
+        User user = (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+        if (status != null) {
+            return taskService.getTasksByUsernameAndStatus(user.getUsername(), type, status);
+        }
+
+        return taskService.getTasksByUsername(user.getUsername(), type);
+    }
 
     @PostMapping()
     public ResponseEntity<Task> createTask(@Validated @RequestBody Task task) {

--- a/byteassist-backend/src/main/java/com/ufpr/byteassist_backend/model/Equipment.java
+++ b/byteassist-backend/src/main/java/com/ufpr/byteassist_backend/model/Equipment.java
@@ -1,0 +1,27 @@
+package com.ufpr.byteassist_backend.model;
+
+import com.surrealdb.RecordId;
+import com.ufpr.byteassist_backend.validation.ValidationGroups;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Null;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class Equipment {
+    @Null(message = "ID should not be provided in the request body, use the URL instead")
+    private RecordId id;
+    
+    @NotBlank(groups = ValidationGroups.Create.class, message = "Brand cannot be blank when creating an equipment")
+    private String brand;
+    
+    @NotBlank(groups = ValidationGroups.Create.class, message = "Model cannot be blank when creating an equipment")
+    private String model;
+    
+    @NotBlank(groups = ValidationGroups.Create.class, message = "Type cannot be blank when creating an equipment")
+    private String type;
+}

--- a/byteassist-backend/src/main/java/com/ufpr/byteassist_backend/model/Person.java
+++ b/byteassist-backend/src/main/java/com/ufpr/byteassist_backend/model/Person.java
@@ -24,24 +24,24 @@ public class Person {
     @Null(message = "ID should not be provided in the request body, use the URL instead")
     private RecordId id;
     
-    @NotBlank(message = "CPF is required", groups = {ValidationGroups.Create.class, ValidationGroups.Update.class})
+    @NotBlank(message = "CPF is required", groups = {ValidationGroups.Create.class})
     @Pattern(regexp = "\\d{11}", message = "CPF must contain exactly 11 digits", groups = {ValidationGroups.Create.class, ValidationGroups.Update.class})
     private String cpf;
     
-    @NotNull
+    @NotNull(groups = {ValidationGroups.Create.class})
     @Past(message = "Date of birth must be in the past")
     @JsonDeserialize(using = SimpleDateDeserializer.class)
     private ZonedDateTime dob;
     
-    @NotBlank
-    @Pattern(regexp = "^(Male|Female|Other)$", message = "Gender must be 'Male', 'Female', or 'Other'")
+    @NotBlank(groups = {ValidationGroups.Create.class})
+    @Pattern(regexp = "^(Male|Female|Other)$", message = "Gender must be 'Male', 'Female', or 'Other'", groups = {ValidationGroups.Create.class, ValidationGroups.Update.class})
     private String gender;
     
-    @NotNull
+    @NotNull(groups = {ValidationGroups.Create.class})
     @Valid
     private PersonAddress address;
     
-    @NotNull 
+    @NotNull(groups = {ValidationGroups.Create.class}) 
     @Valid
     private PersonName name;
 }

--- a/byteassist-backend/src/main/java/com/ufpr/byteassist_backend/model/User.java
+++ b/byteassist-backend/src/main/java/com/ufpr/byteassist_backend/model/User.java
@@ -14,6 +14,7 @@ import com.ufpr.byteassist_backend.validation.ValidationGroups;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Null;
+import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -22,10 +23,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class User implements UserDetails {
-    @Null(groups = ValidationGroups.Update.class, message = "ID must not be provided in update requests")
+    @Null(message = "ID must not be provided in update requests")
     private RecordId id;
     
-    @NotBlank(message = "Email cannot be blank")
+    @NotBlank(groups = ValidationGroups.Create.class, message = "Email cannot be blank")
     @Email(message = "Email should be valid")
     private String email;
 
@@ -41,8 +42,8 @@ public class User implements UserDetails {
     
     private UserTime time;
 
-    @NotBlank(message = "Type cannot be blank")
-    @jakarta.validation.constraints.Pattern(regexp = "^(Client|Admin|Manager|Employee)$", message = "Type must be either 'Client' or 'Admin'")
+    @NotBlank(groups = ValidationGroups.Create.class, message = "Type cannot be blank")
+    @Pattern(regexp = "^(Client|Admin|Manager|Employee)$", message = "Type must be either 'Client' or 'Admin'")
     private String role = "Client";
 
     @Override

--- a/byteassist-backend/src/main/java/com/ufpr/byteassist_backend/repository/EquipmentRepo.java
+++ b/byteassist-backend/src/main/java/com/ufpr/byteassist_backend/repository/EquipmentRepo.java
@@ -1,0 +1,94 @@
+package com.ufpr.byteassist_backend.repository;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.stereotype.Repository;
+
+import com.surrealdb.RecordId;
+import com.surrealdb.Response;
+import com.surrealdb.Surreal;
+import com.surrealdb.UpType;
+import com.ufpr.byteassist_backend.model.Equipment;
+import com.ufpr.byteassist_backend.service.DatabaseService;
+
+@Repository
+public class EquipmentRepo implements EquipmentRepoInterface {
+    private final Surreal db;
+    
+    public EquipmentRepo(DatabaseService databaseService) {
+        this.db = databaseService.getDatabase();
+    }
+    
+    @Override
+    public Optional<List<Equipment>> getAllEquipments() {
+        try {
+            Iterator<Equipment> equipments = db.select(Equipment.class, "Equipment");
+            List<Equipment> equipmentList = new ArrayList<>();
+            equipments.forEachRemaining(equipmentList::add);
+            return Optional.ofNullable(equipmentList);
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+    }
+    
+    @Override
+    public Optional<Equipment> getEquipmentById(String id) {
+        try {
+            return db.select(Equipment.class, new RecordId("Equipment", id));
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+    }
+    
+    @Override
+    public Optional<Equipment> createEquipment(Equipment equipment) {
+        try {
+            return Optional.ofNullable(db.create(Equipment.class, 
+                new RecordId("Equipment", "EQ-" + UUID.randomUUID().toString().replace("-", "").substring(0, 5).toUpperCase()), 
+                equipment));
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+    }
+    
+    @Override
+    public Boolean deleteEquipment(String id) {
+        try {
+            db.delete(new RecordId("Equipment", id));
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @Override
+    public Optional<Equipment> updateEquipment(Equipment equipment, String id) {
+        try {
+            return Optional.ofNullable(db.update(Equipment.class, new RecordId("Equipment", id), UpType.MERGE, equipment));
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+    }
+    
+    @Override
+    public Optional<List<Equipment>> getEquipmentsByType(String type) {
+        try {
+            String query = "SELECT * FROM Equipment WHERE type = $type";
+            Response response = db.queryBind(query, Map.of("type", type));
+            
+            List<Equipment> equipments = new ArrayList<>();
+            for (var equipmentRecord : response.take(0).getArray()) {
+                Equipment equipment = equipmentRecord.get(Equipment.class);
+                equipments.add(equipment);
+            }
+            return Optional.of(equipments);
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/byteassist-backend/src/main/java/com/ufpr/byteassist_backend/repository/EquipmentRepoInterface.java
+++ b/byteassist-backend/src/main/java/com/ufpr/byteassist_backend/repository/EquipmentRepoInterface.java
@@ -1,0 +1,15 @@
+package com.ufpr.byteassist_backend.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.ufpr.byteassist_backend.model.Equipment;
+
+public interface EquipmentRepoInterface {
+    public Optional<List<Equipment>> getAllEquipments();
+    public Optional<Equipment> getEquipmentById(String id);
+    public Optional<Equipment> createEquipment(Equipment equipment);
+    public Boolean deleteEquipment(String id);
+    public Optional<Equipment> updateEquipment(Equipment equipment, String id);
+    public Optional<List<Equipment>> getEquipmentsByType(String type);
+}

--- a/byteassist-backend/src/main/java/com/ufpr/byteassist_backend/repository/TaskRepo.java
+++ b/byteassist-backend/src/main/java/com/ufpr/byteassist_backend/repository/TaskRepo.java
@@ -49,8 +49,10 @@ public class TaskRepo implements TaskRepoInterface {
     public Optional<List<Task>> getTasksByUsernameAndStatus(String username, String type, String status) {
         try {
             // Build query dynamically based on type parameter
-            String fieldToQuery = type.equals("creator") ? "creator.id.id()" : "asignee.id.id()";
+            String fieldToQuery = type.equals("creator") ? "creator.id.id()" : "assignee.id.id()";
             String query = "SELECT * FROM Task WHERE " + fieldToQuery + " = $user AND status = $status";
+            
+            System.out.println("Executing query: " + query + " with user: " + username + " and status: " + status);
             
             Response response = db.queryBind(query, Map.of("user", username, "status", status));
             

--- a/byteassist-backend/src/main/java/com/ufpr/byteassist_backend/service/EquipmentService.java
+++ b/byteassist-backend/src/main/java/com/ufpr/byteassist_backend/service/EquipmentService.java
@@ -1,0 +1,91 @@
+package com.ufpr.byteassist_backend.service;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import com.ufpr.byteassist_backend.exception.EnhancedStatusException;
+import com.ufpr.byteassist_backend.model.Equipment;
+import com.ufpr.byteassist_backend.repository.EquipmentRepoInterface;
+
+@Service
+public class EquipmentService {
+    private final EquipmentRepoInterface equipmentRepo;
+
+    public EquipmentService(EquipmentRepoInterface equipmentRepo) {
+        this.equipmentRepo = equipmentRepo;
+    }
+    
+    public ResponseEntity<List<Equipment>> getAllEquipments() {
+        Optional<List<Equipment>> equipments = equipmentRepo.getAllEquipments();
+        if (equipments.isEmpty()) {
+            throw new EnhancedStatusException(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                "Error retrieving all equipments from database",
+                "There was a problem accessing the database to retrieve the list of equipments"
+            );
+        }
+        return ResponseEntity.ok(equipments.get());
+    }
+    
+    public ResponseEntity<Equipment> getEquipmentById(String id) {
+        Optional<Equipment> equipment = equipmentRepo.getEquipmentById(id);
+        if (equipment.isEmpty()) {
+            throw new EnhancedStatusException(
+                HttpStatus.NOT_FOUND,
+                "Equipment not found",
+                "No equipment found with the provided ID"
+            );
+        }
+        return ResponseEntity.ok(equipment.get());
+    }
+    
+    public ResponseEntity<Equipment> createEquipment(Equipment equipment) {
+        Optional<Equipment> createdEquipment = equipmentRepo.createEquipment(equipment);
+        if (createdEquipment.isEmpty()) {
+            throw new EnhancedStatusException(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                "Error creating equipment",
+                "There was a problem accessing the database to create the equipment"
+            );
+        }
+        return ResponseEntity.status(HttpStatus.CREATED).body(createdEquipment.get());
+    }
+    
+    public ResponseEntity<Equipment> updateEquipment(String id, Equipment equipment) {
+        Equipment updatedEquipment = equipmentRepo.updateEquipment(equipment, id).orElseThrow(
+            () -> new EnhancedStatusException(
+                HttpStatus.NOT_FOUND,
+                "Equipment not found",
+                "No equipment found with the provided ID"
+            ));
+        return ResponseEntity.ok(updatedEquipment);
+    }
+    
+    public ResponseEntity<Void> deleteEquipment(String id) {
+        boolean deleted = equipmentRepo.deleteEquipment(id);
+        if (!deleted) {
+            throw new EnhancedStatusException(
+                HttpStatus.NOT_FOUND,
+                "Equipment not found",
+                "No equipment found with the provided ID"
+            );
+        }
+        return ResponseEntity.noContent().build();
+    }
+    
+    public ResponseEntity<List<Equipment>> getEquipmentsByType(String type) {
+        Optional<List<Equipment>> equipments = equipmentRepo.getEquipmentsByType(type);
+        if (equipments.isEmpty()) {
+            throw new EnhancedStatusException(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                "Error retrieving equipments by type from database",
+                "There was a problem accessing the database to retrieve the list of equipments"
+            );
+        }
+        return ResponseEntity.ok(equipments.get());
+    }
+}


### PR DESCRIPTION
Introduce an endpoint to fetch tasks for the current user with optional filters for type and status, enhancing user experience. Improve validation constraints in the `Person`, `User`, and `Equipment` models to enforce stricter rules during creation while maintaining flexibility for updates. Fix a typo in the dynamic query logic for task retrieval and add logging for better debugging.

## Summary by Sourcery

Add a self-service task endpoint for the current user, introduce Equipment CRUD functionality, refine model validation rules, and fix a dynamic query typo with added logging.

New Features:
- Add endpoint to retrieve tasks for the authenticated user with optional type and status filters
- Implement full CRUD APIs for Equipment including listing, filtering by type, creation, update, and deletion

Bug Fixes:
- Correct typo in TaskRepo dynamic query field name from "asignee" to "assignee"

Enhancements:
- Enforce stricter create-only validation constraints on Person, User, and Equipment models
- Add query execution logging in TaskRepo for improved debugging