### PR TITLE
corrige a correção anterior

### DIFF
--- a/byteassist-frontend/src/app/features/pages/list-my-tasks/list-my-tasks.component.ts
+++ b/byteassist-frontend/src/app/features/pages/list-my-tasks/list-my-tasks.component.ts
@@ -53,12 +53,12 @@ export class ListMyTasksComponent implements OnInit {
   // ordemCrescente: boolean = true;
 
   constructor(
-    // private readonly service: EmployeeService,    // EMPLOYEE
-   // private readonly router: Router,
-    //private readonly taskService: TaskService
-  //) { }
-  //@ViewChild(ModalListMyTaskVisualizarComponent)
-  //modalVisualizar!: ModalListMyTaskVisualizarComponent;
+    //private readonly service: EmployeeService,    // EMPLOYEE
+    private readonly router: Router,
+    private readonly taskService: TaskService
+  ) { }
+  @ViewChild(ModalListMyTaskVisualizarComponent)
+  modalVisualizar!: ModalListMyTaskVisualizarComponent;
 
   // ===== (EMPLOYEE: comentado) =====
   // @ViewChild(ModalEmployeeVisualizarComponent)
@@ -91,7 +91,7 @@ export class ListMyTasksComponent implements OnInit {
     //this.modalEmployeeEditar.abrirModal(); // abre o modal
   //}
 
-  ngOnInit(): void {
+  //ngOnInit(): void {
     this.taskService.getAllMyTasks('creator', undefined, 'equipment').subscribe({
       next: (tasks) => {
         console.log('Tasks recebidas:', tasks);


### PR DESCRIPTION
## Summary by Sourcery

Update ListMyTasksComponent to restore its constructor injections and modal reference while disabling the initialization hook.

Enhancements:
- Re-enable Router and TaskService dependency injections in the component constructor
- Restore the @ViewChild modalVisualizar property for task viewing
- Comment out the ngOnInit signature to temporarily disable component initialization logic