### PR TITLE
feat: update comment creation to associate with authenticated user an…

### DIFF
--- a/byteassist-backend/src/main/java/com/ufpr/byteassist_backend/controller/CommentController.java
+++ b/byteassist-backend/src/main/java/com/ufpr/byteassist_backend/controller/CommentController.java
@@ -3,6 +3,7 @@ package com.ufpr.byteassist_backend.controller;
 import java.util.List;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.ufpr.byteassist_backend.model.Comment;
+import com.ufpr.byteassist_backend.model.User;
 import com.ufpr.byteassist_backend.service.CommentService;
 import com.ufpr.byteassist_backend.validation.ValidationGroups;
 
@@ -33,6 +35,8 @@ public class CommentController {
 
     @PostMapping
     public ResponseEntity<Comment> createComment(@Validated(ValidationGroups.Create.class) @RequestBody Comment comment) {
+        User user = (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        comment.setIn(user.getId());
         return commentService.createComment(comment);
     }
 

--- a/byteassist-backend/src/main/java/com/ufpr/byteassist_backend/model/Comment.java
+++ b/byteassist-backend/src/main/java/com/ufpr/byteassist_backend/model/Comment.java
@@ -21,7 +21,7 @@ public class Comment extends InsertRelation {
     @Null(message = "ID should not be provided in the request body")
     private RecordId id;
     
-    @NotNull(groups = ValidationGroups.Create.class, message = "In ID cannot be null")
+    @Null(groups = ValidationGroups.Create.class, message = "In ID should not be provided in the request body as it will be taken from the authenticated user")
     private RecordId in;
     
     @NotNull(groups = ValidationGroups.Create.class, message = "Out ID cannot be null")

--- a/byteassist-frontend/src/app/features/pages/task-view/task-view.component.ts
+++ b/byteassist-frontend/src/app/features/pages/task-view/task-view.component.ts
@@ -29,16 +29,6 @@ export class TaskViewComponent implements OnInit {
   budget: Budget | null = null;
   loading = true;
   error = false;
-  // comments = [
-  //   {
-  //     author: 'Victor Bilbao',
-  //   },
-  //   {
-  //     author: 'Maria Silva',
-  //     date: new Date(),
-  //     text: 'Outro comentário mock com *itálico*.',
-  //   },
-  // ];
   comments: Comment[] = [];
   newCommentText: string = '';
 
@@ -81,7 +71,7 @@ export class TaskViewComponent implements OnInit {
     if (this.newCommentText.trim() && this.task) {
       const newComment: Comment = {
         in: 'Usuário Atual (mock)',
-        comment_date: new Date(),
+        out: "teste",
         comment: this.newCommentText.trim(),
       };
       this.comments.push(newComment);


### PR DESCRIPTION
…d adjust validation for 'in' field

## Summary by Sourcery

Automatically assign new comments to the authenticated user, tighten validation to disallow client-supplied ‘in’ values, and update the frontend comment flow by cleaning up mocks and emitting the ‘out’ field.

New Features:
- Associate new comments with the authenticated user by setting the ‘in’ field server-side.

Enhancements:
- Enforce that the ‘in’ field must be omitted in incoming create requests via updated validation rules.
- Remove hard-coded mock comments and adjust the frontend to send an ‘out’ field in new comment submissions.