### PR TITLE
corrige método updateTask

### DIFF
--- a/byteassist-frontend/src/app/features/pages/new-request/new-request.component.ts
+++ b/byteassist-frontend/src/app/features/pages/new-request/new-request.component.ts
@@ -21,7 +21,7 @@ export class NewRequestComponent {
   equipmentService = inject(EquipmentService);
   recordIdService = inject(RecordidService);
   equipment: Equipment = {};
-  task: Task = {};
+  task: Task = {} as Task;
 
   // Solicitation model for form binding
   solicitation: any = {
@@ -52,7 +52,7 @@ export class NewRequestComponent {
   ];
 
   // Injeção de dependências
-  constructor(private readonly router: Router) {}
+  constructor(private readonly router: Router) { }
 
   // Placeholder for register logic
   createSolicitacao() {

--- a/byteassist-frontend/src/app/features/pages/task-view/task-view.component.ts
+++ b/byteassist-frontend/src/app/features/pages/task-view/task-view.component.ts
@@ -134,12 +134,14 @@ export class TaskViewComponent implements OnInit {
               },
               error: (err) => {
                 console.error('Erro ao adicionar comentário de histórico', err);
+                task.status = 'REJEITADA'; // Reverte o status se falhar
                 Swal.fire('Aviso', 'Status alterado, mas não foi possível registrar histórico', 'warning');
               }
             });
         },
         error: (err) => {
           console.error('Falha ao resgatar serviço', err);
+          task.status = 'REJEITADA'; // Reverte o status se falhar
           Swal.fire('Erro', 'Não foi possível atualizar o status', 'error');
         }
       });

--- a/byteassist-frontend/src/app/features/services/task/task.service.ts
+++ b/byteassist-frontend/src/app/features/services/task/task.service.ts
@@ -121,7 +121,7 @@ export class TaskService {
       'Authorization': `Bearer ${this.authService.getToken()}` // Adiciona o token no header
     });
     this.loadingService.show(); // Exibe o loading
-    return this.http.patch<Task>(`${this.apiUrl}/${task.id}?expand=equipment`, taskPayload, { headers }).pipe(
+    return this.http.patch<Task>(`${this.apiUrl}/${task.id}`, taskPayload, { headers }).pipe(
       finalize(() => this.loadingService.hide()), // Esconde o loading após a requisição
     );
   }

--- a/byteassist-frontend/src/app/features/shared/models/task.model.ts
+++ b/byteassist-frontend/src/app/features/shared/models/task.model.ts
@@ -6,7 +6,7 @@ export interface Task {
   assignee?: string;
   creator?: string;
   budget?: string;
-  equipment: string | Equipment;
+  equipment?: string | Equipment;
   status?: string;
   summary?: string;
   title?: string;


### PR DESCRIPTION
## Summary by Sourcery

Refine the task update flow by adjusting the API call, model definitions, component initialization, and error rollback logic.

Bug Fixes:
- Revert task status to 'REJEITADA' when updating status or logging history fails in TaskViewComponent

Enhancements:
- Remove the 'expand=equipment' query parameter from the task update API endpoint
- Make the equipment field optional in the Task model
- Cast task initialization to the Task type in NewRequestComponent

Chores:
- Clean up constructor formatting in NewRequestComponent