### PR TITLE
corrige css

### DIFF
--- a/byteassist-frontend/src/app/features/pages/task-view/task-view.component.css
+++ b/byteassist-frontend/src/app/features/pages/task-view/task-view.component.css
@@ -44,6 +44,13 @@
 .task-comments {
   margin-top: 2rem;
 }
+
+.comment-body {
+  word-break: break-word;
+  overflow-wrap: break-word;
+  white-space: pre-wrap;
+}
+
 .comments-list .comment {
   background: #f8f9fa;
   border: 1px solid #e3e3e3;


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Add CSS rules to .comment-body to enable word-break, overflow-wrap, and pre-wrap whitespace