### PR TITLE
fix: remove unnecessary separator and adjust layout in admin menu links

### DIFF
--- a/byteassist-frontend/src/app/features/components/menu-sidebar/menu-sidebar.component.html
+++ b/byteassist-frontend/src/app/features/components/menu-sidebar/menu-sidebar.component.html
@@ -105,9 +105,6 @@
           <p class="nav-link-text">Suporte</p>
         </a>
       </li>
-      <li class="nav-item nav-item-seperator">
-        <div class="nav-border"></div>
-      </li>
 
 
       <li class="nav-item" *ngIf="adminLinksVisible">
@@ -115,10 +112,10 @@
           class="nav-link flex items-center menu-padding"
           routerLink="/admin/funcionarios"
           routerLinkActive="active"
-        >
+          >
           <img src="/images/menu-sidebar/folder.png" class="menu-icon">
           <p class="nav-link-text">Funcionários</p>
-        </a>
+          </a>
       </li>
 
       <li class="nav-item" *ngIf="adminLinksVisible">
@@ -126,10 +123,14 @@
           class="nav-link flex items-center menu-padding"
           routerLink="/admin/cadastrar-funcionario"
           routerLinkActive="active"
-        >
+          >
           <img src="/images/menu-sidebar/folder.png" class="menu-icon">
           <p class="nav-link-text">Cadastrar Funcionario</p>
         </a>
+      </li>
+
+      <li class="nav-item nav-item-seperator">
+        <div class="nav-border"></div>
       </li>
 
       <li class="nav-item">
@@ -141,7 +142,6 @@
           <p class="nav-link-text">Logout</p>
         </a>
       </li>
-
     </ul>
   </nav>
 


### PR DESCRIPTION
## Summary by Sourcery

Remove an extraneous separator in the admin menu, reposition the divider after the second admin link, and adjust HTML indentation for consistency

Bug Fixes:
- Eliminate redundant separator before admin menu links
- Reposition the menu divider to follow the second admin link

Enhancements:
- Normalize indentation of anchor tags in the sidebar markup