### PR TITLE
feature: add status toggle functionality for equipment types in editi…

### DIFF
--- a/byteassist-frontend/src/app/features/pages-admin/categories/categories.component.html
+++ b/byteassist-frontend/src/app/features/pages-admin/categories/categories.component.html
@@ -48,9 +48,19 @@
           <!-- Status -->
           <td>
             <span
+              *ngIf="row.isEditing"
               [class.status-active]="row.equipmentType.active"
               [class.status-inactive]="!row.equipmentType.active"
               (click)="toggleStatus(row)"
+              class="status-toggle"
+            >
+              {{ row.equipmentType.active ? 'Ativa' : 'Inativa' }}
+            </span>
+
+            <span
+              *ngIf="!row.isEditing"
+              [class.status-active]="row.equipmentType.active"
+              [class.status-inactive]="!row.equipmentType.active"
             >
               {{ row.equipmentType.active ? 'Ativa' : 'Inativa' }}
             </span>


### PR DESCRIPTION
…ng mode

## Summary by Sourcery

Restrict the status toggle interaction for equipment types to editing mode and display a non-interactive status label otherwise.

New Features:
- Allow toggling equipment type status only when a row is in editing mode

Enhancements:
- Render a read-only status label in view-only mode without the toggle click handler