### PR TITLE
refactor: remove unnecessary whitespace and separator from menu sidebar

### DIFF
--- a/byteassist-frontend/src/app/features/components/menu-sidebar/menu-sidebar.component.html
+++ b/byteassist-frontend/src/app/features/components/menu-sidebar/menu-sidebar.component.html
@@ -81,7 +81,7 @@
           <p class="nav-link-text">Orçamentos</p>
         </a>
       </li>
-      
+
       <li class="nav-item" *ngIf="employeeLinksVisible">
         <a
           class="nav-link flex items-center menu-padding"
@@ -93,10 +93,6 @@
         </a>
       </li>
 
-      <li class="nav-item nav-item-seperator">
-        <div class="nav-border"></div>
-      </li>
-      
       <!--Employee- END -->
 
       <li class="nav-item" *ngIf="clientLinksVisible">
@@ -128,9 +124,10 @@
           class="nav-link flex items-center menu-padding"
           routerLink="/admin/funcionarios"
           routerLinkActive="active"
+        >
 
           <img src="/images/menu-sidebar/employee-icon.png" class="menu-icon">
-        
+
           <p class="nav-link-text">Funcionários</p>
         </a>
       </li>
@@ -140,9 +137,10 @@
           class="nav-link flex items-center menu-padding"
           routerLink="/admin/cadastrar-funcionario"
           routerLinkActive="active"
-          
+        >
+
           <img src="/images/menu-sidebar/new-employee-icon.png" class="menu-icon">
-        
+
           <p class="nav-link-text">Cadastrar Funcionario</p>
         </a>
       </li>


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Clean up HTML by deleting superfluous whitespace and a deprecated separator in the menu sidebar template.